### PR TITLE
Remove ano do rodapé dos emails

### DIFF
--- a/sme_ofertaimoveis/templates/base/footer.html
+++ b/sme_ofertaimoveis/templates/base/footer.html
@@ -1,6 +1,6 @@
 <footer class="footer">
     <div class="container text-center p-5">
-      <span class="text-muted ">Prefeitura da Cidade de São Paulo - 2019</span>
+      <span class="text-muted ">Prefeitura da Cidade de São Paulo</span>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
No rodapé dos emails enviados ao munícipe e ao COGED, o ano 2019 estava hardcoded.