### PR TITLE
Feature/37755 erro fluxo step

### DIFF
--- a/sme_ofertaimoveis/dados_comuns/models.py
+++ b/sme_ofertaimoveis/dados_comuns/models.py
@@ -134,6 +134,8 @@ class LogFluxoStatus(models.Model):
         data = datetime.strftime(self.criado_em, '%Y-%m-%d %H:%M:%S')
         return (f'{self.usuario.first_name} {self.usuario.last_name} executou {self.get_status_evento_display()} no dia {data}')
 
+    class Meta:
+        ordering = ('id',)
 
 class AnexoLog(models.Model):
     TIPO_DOCUMENTO = (

--- a/sme_ofertaimoveis/imovel/templates/imovel/relatorios/relatorio_cadastro.html
+++ b/sme_ofertaimoveis/imovel/templates/imovel/relatorios/relatorio_cadastro.html
@@ -58,7 +58,7 @@
       <div>
         <ul class="progressbar-titles fluxos">
           {% for status in fluxo|or_logs:logs %}
-          <li style="width: 10%">
+          <li style="{% if fluxo|or_logs:logs|is_bigger_than_flow:fluxo %} width: 9.09% {% else %} width: 10% {% endif %}">
             {% if logs|index_exists:forloop.counter %}
             {{ logs|get_element_by_index:forloop.counter0|get_attribute:'status_evento_explicacao'}}
             {% else %}
@@ -72,7 +72,7 @@
             <li class="{% if logs|index_exists:forloop.counter %}
                       {{ logs|get_element_by_index:forloop.counter0|class_css }}
                       {% else %}{% if logs|fim_de_fluxo %} {% else %}pending{% endif %}{% endif %}"
-              style="width: 10%">
+              style="{% if fluxo|or_logs:logs|is_bigger_than_flow:fluxo %} width: 9.09% {% else %} width: 10% {% endif %}">
               {% if logs|index_exists:forloop.counter %}
                 <span class="criado_em">
                   {{ logs|get_element_by_index:forloop.counter0|get_attribute:'criado_em' }}

--- a/sme_ofertaimoveis/imovel/templatetags/index.py
+++ b/sme_ofertaimoveis/imovel/templatetags/index.py
@@ -50,3 +50,8 @@ def index_exists(indexable, i):
 @register.filter
 def or_logs(fluxo, logs):
     return logs if len(logs) > len(fluxo) else fluxo
+
+# verifica se o fluxo usado é maior que a linha do tempo
+@register.filter
+def is_bigger_than_flow(logs, fluxo):
+    return True if len(logs) > len(fluxo) else False


### PR DESCRIPTION
# Proposta

Este PR visa corrigir espaçamento entre os itens do fluxo e fixar ordem de exibição. 
 
# Referência do Azure

- 37755

# Tarefas para concluir

- [x] ordenar logs por ID.
- [x] definir espaço entre fluxos quando o log tem mais itens que os steps.