### PR TITLE
Feature/40893 substituir descritivo auditoria botao exportar detalhamento cadastro

### DIFF
--- a/sme_ofertaimoveis/imovel/templates/imovel/relatorios/relatorio_cadastro.html
+++ b/sme_ofertaimoveis/imovel/templates/imovel/relatorios/relatorio_cadastro.html
@@ -258,7 +258,7 @@
       </div>
       <div class="row">
         <div class="col-6 auditoria">
-          <label class="mt-3 ">Auditoria feita por: {{solicitante_nome}}, {{solicitante_rf}} - {{data_hoje}}</label>
+          <label class="mt-3 ">Relatório extraído em {{data_hoje}}</label>
         </div>
         <div class="col-6">
           <label class="data-atualizacao">Atualização DIE: {{data_atualizacao_demanda}}</label>


### PR DESCRIPTION
Esse PR contém:

* Substitui descritivo da auditoria do botão exportar.

[historia - 40893](https://dev.azure.com/amcomgov/SME%20-%20Cadastro%20de%20Im%C3%B3veis/_sprints/taskboard/SME%20-%20Cadastro%20de%20Im%C3%B3veis%20Team/SME%20-%20Cadastro%20de%20Im%C3%B3veis/Im%C3%B3veis%20-%20Sprint%2010%20-%20Sustenta%C3%A7%C3%A3o%20Junho?workitem=40893)